### PR TITLE
feat: wrote localizer for strings in parsers

### DIFF
--- a/src/LocalizerInterface.php
+++ b/src/LocalizerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser;
+
+interface LocalizerInterface
+{
+    /**
+     *
+     * @param string $translateString
+     * @return array<string, string>
+     */
+    public function getAllTranslationsForString(string $translateString): array;
+}

--- a/src/ParserLocalizer.php
+++ b/src/ParserLocalizer.php
@@ -57,24 +57,13 @@ final class ParserLocalizer implements LocalizerInterface
 
     public function getAllTranslationsForString(string $translateString): array
     {
-        switch (strtolower($translateString)) {
-            case 'row':
-                return $this->rowLabels;
-
-            case 'positive':
-                return $this->positiveLabels;
-
-            case 'text':
-                return $this->textLabels;
-
-            case 'true':
-                return $this->trueLabels;
-
-            case 'false':
-                return $this->falseLabels;
-
-            default:
-                throw new \InvalidArgumentException("Could not find translation for {$translateString}");
-        }
+        return match (strtolower($translateString)) {
+            'row' => $this->rowLabels,
+            'positive' => $this->positiveLabels,
+            'text' => $this->textLabels,
+            'true' => $this->trueLabels,
+            'false' => $this->falseLabels,
+            default => throw new \InvalidArgumentException("Could not find translation for {$translateString}"),
+        };
     }
 }

--- a/src/ParserLocalizer.php
+++ b/src/ParserLocalizer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser;
+
+final class ParserLocalizer implements LocalizerInterface
+{
+    /** @var array<string, string> $rowLabels */
+    private array $rowLabels;
+    /** @var array<string, string> $positiveLabels */
+    private array $positiveLabels;
+    /** @var array<string, string> $textLabels */
+    private array $textLabels;
+    /** @var array<string, string> $trueLabels */
+    private array $trueLabels;
+    /** @var array<string, string> $falseLabels */
+    private array $falseLabels;
+
+    /**
+     * Create a new ParserLocalizer
+     * @param null|array<string, string> $rowLabels
+     * @param null|array<string, string> $positiveLabels
+     * @param null|array<string, string> $textLabels
+     * @param null|array<string, string> $trueLabels
+     * @param null|array<string, string> $falseLabels
+     * @return self
+     */
+    public function __construct(
+        ?array $rowLabels = null,
+        ?array $positiveLabels = null,
+        ?array $textLabels = null,
+        ?array $trueLabels = null,
+        ?array $falseLabels = null,
+    ) {
+        $this->rowLabels = $rowLabels ?? [
+            "default" => "Row",
+        ];
+
+        $this->positiveLabels = $positiveLabels ?? [
+            "default" => "Positive",
+        ];
+
+        $this->textLabels = $textLabels ?? [
+            "default" => "Text",
+        ];
+
+        $this->trueLabels = $trueLabels ?? [
+            "default" => "True",
+        ];
+
+
+        $this->falseLabels = $falseLabels ?? [
+            "default" => "False",
+        ];
+    }
+
+    public function getAllTranslationsForString(string $translateString): array
+    {
+        switch (strtolower($translateString)) {
+            case 'row':
+                return $this->rowLabels;
+
+            case 'positive':
+                return $this->positiveLabels;
+
+            case 'text':
+                return $this->textLabels;
+
+            case 'true':
+                return $this->trueLabels;
+
+            case 'false':
+                return $this->falseLabels;
+
+            default:
+                throw new \InvalidArgumentException("Could not find translation for {$translateString}");
+        }
+    }
+}

--- a/tests/ParserLocalizerTest.php
+++ b/tests/ParserLocalizerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser\Tests;
+
+use Collecthor\SurveyjsParser\ParserLocalizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Collecthor\SurveyjsParser\ParserLocalizer
+ */
+final class ParserLocalizerTest extends TestCase
+{
+    public function testDefaultValues(): void
+    {
+        $localizer = new ParserLocalizer();
+        
+        self::assertSame('Row', $localizer->getAllTranslationsForString('Row')['default']);
+        self::assertSame('Positive', $localizer->getAllTranslationsForString('Positive')['default']);
+        self::assertSame('Text', $localizer->getAllTranslationsForString('Text')['default']);
+        self::assertSame('True', $localizer->getAllTranslationsForString('True')['default']);
+        self::assertSame('False', $localizer->getAllTranslationsForString('False')['default']);
+    }
+
+    public function testSingleCustomValue(): void
+    {
+        $localizer = new ParserLocalizer(trueLabels:['default' => 'True test']);
+
+        self::assertSame('Row', $localizer->getAllTranslationsForString('Row')['default']);
+        self::assertSame('Positive', $localizer->getAllTranslationsForString('Positive')['default']);
+        self::assertSame('Text', $localizer->getAllTranslationsForString('Text')['default']);
+        self::assertSame('True test', $localizer->getAllTranslationsForString('True')['default']);
+        self::assertSame('False', $localizer->getAllTranslationsForString('False')['default']);
+    }
+
+    public function testMultipleLanguages(): void
+    {
+        $localizer = new ParserLocalizer(trueLabels:['default' => 'True', 'nl' => 'Waar']);
+
+        self::assertSame('Row', $localizer->getAllTranslationsForString('Row')['default']);
+        self::assertSame('Positive', $localizer->getAllTranslationsForString('Positive')['default']);
+        self::assertSame('Text', $localizer->getAllTranslationsForString('Text')['default']);
+        self::assertSame('True', $localizer->getAllTranslationsForString('True')['default']);
+        self::assertSame('False', $localizer->getAllTranslationsForString('False')['default']);
+        self::assertSame('Waar', $localizer->getAllTranslationsForString('True')['nl']);
+    }
+}


### PR DESCRIPTION
Wrote an interface for storing translations for certain strings needed for parsers. This is especially useful for when using words such as "row" in a parser's output, so this can be localized as well.

This interface, `LocalizerInterface` has been implemented as `ParserLocalizer` with some sensible defaults. 