### PR TITLE
feat: add variable and parser for ordered variables

### DIFF
--- a/src/Parsers/OrderedVariableParser.php
+++ b/src/Parsers/OrderedVariableParser.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser\Parsers;
+
+use Collecthor\SurveyjsParser\ElementParserInterface;
+use Collecthor\SurveyjsParser\ParserHelpers;
+use Collecthor\SurveyjsParser\SurveyConfiguration;
+use Collecthor\SurveyjsParser\Variables\OrderedVariable;
+
+final class OrderedVariableParser implements ElementParserInterface
+{
+    use ParserHelpers;
+
+    public function parse(ElementParserInterface $root, array $questionConfig, SurveyConfiguration $surveyConfiguration, array $dataPrefix = []): iterable
+    {
+        $dataPath = [...$dataPrefix, $this->extractValueName($questionConfig)];
+
+        $name = $this->extractName($questionConfig);
+
+        $titles = $this->extractTitles($questionConfig, $surveyConfiguration);
+
+        $choices = $this->extractChoices($this->extractArray($questionConfig, 'choices'), $surveyConfiguration);
+
+        yield new OrderedVariable($name, $titles, $choices, $dataPath, $questionConfig);
+    }
+}

--- a/src/Variables/OrderedVariable.php
+++ b/src/Variables/OrderedVariable.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser\Variables;
+
+use Collecthor\DataInterfaces\ClosedVariableInterface;
+use Collecthor\DataInterfaces\Measure;
+use Collecthor\DataInterfaces\RecordInterface;
+use Collecthor\DataInterfaces\StringValueInterface;
+use Collecthor\DataInterfaces\ValueInterface;
+use Collecthor\DataInterfaces\ValueOptionInterface;
+use Collecthor\DataInterfaces\ValueSetInterface;
+use Collecthor\SurveyjsParser\Traits\GetName;
+use Collecthor\SurveyjsParser\Traits\GetRawConfiguration;
+use Collecthor\SurveyjsParser\Traits\GetTitle;
+use Collecthor\SurveyjsParser\Values\InvalidValue;
+use Collecthor\SurveyjsParser\Values\StringValue;
+use Collecthor\SurveyjsParser\Values\ValueSet;
+
+final class OrderedVariable implements ClosedVariableInterface
+{
+    use GetName, GetTitle, GetRawConfiguration;
+
+    /**
+     * @var array<string, ValueOptionInterface>
+     */
+    private array $valueMap = [];
+
+    /**
+     * @param string $name
+     * @param array<string, string> $titles
+     * @param non-empty-list<ValueOptionInterface> $valueOptions
+     * @param array<string, mixed> $rawConfiguration
+     */
+    public function __construct(
+        string $name,
+        array $titles,
+        array $valueOptions,
+        /**
+         * @phpstan-var non-empty-list<string>
+         */
+        private array $dataPath,
+        array $rawConfiguration = []
+    ) {
+        $this->name = $name;
+
+        foreach ($valueOptions as $valueOption) {
+            $this->valueMap[(string) $valueOption->getRawValue()] = $valueOption;
+        }
+
+        $this->titles = $titles;
+        $this->rawConfiguration = $rawConfiguration;
+    }
+
+    public function getValueOptions(): array
+    {
+        return array_values($this->valueMap);
+    }
+
+    public function getValue(RecordInterface $record): ValueInterface|ValueSetInterface
+    {
+        $rawValues = $record->getDataValue($this->dataPath);
+        if (!is_array($rawValues)) {
+            return new InvalidValue($rawValues);
+        }
+
+        $values = [];
+
+        foreach ($rawValues as $value) {
+            /** @var string $value */
+            if (isset($this->valueMap[(string) $value])) {
+                $values[] = $this->valueMap[(string) $value];
+            } else {
+                return new InvalidValue($rawValues);
+            }
+        }
+        return new ValueSet(...$values);
+    }
+
+    public function getDisplayValue(RecordInterface $record, ?string $locale = null): StringValueInterface
+    {
+        /** @var ValueSetInterface $valueSet */
+        $valueSet = $this->getValue($record);
+        $values = $valueSet->getValues();
+
+        $displayValues = array_map(fn (ValueOptionInterface $val) => $val->getDisplayValue($locale), $values);
+        return new StringValue(implode(", ", $displayValues));
+    }
+
+    public function getMeasure(): Measure
+    {
+        return Measure::Nominal;
+    }
+}

--- a/tests/Parsers/OrderedVariableParserTest.php
+++ b/tests/Parsers/OrderedVariableParserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser\Tests\Parsers;
+
+use Collecthor\SurveyjsParser\Parsers\DummyParser;
+use Collecthor\SurveyjsParser\Parsers\OrderedVariableParser;
+use Collecthor\SurveyjsParser\SurveyConfiguration;
+use Collecthor\SurveyjsParser\Variables\OrderedVariable;
+use PHPUnit\Framework\TestCase;
+
+use function iter\toArray;
+
+/**
+ * @covers \Collecthor\SurveyjsParser\Parsers\OrderedVariableParser
+ * @uses \Collecthor\SurveyjsParser\Values\StringValueOption
+ * @uses \Collecthor\SurveyjsParser\Variables\OrderedVariable
+ */
+final class OrderedVariableParserTest extends TestCase
+{
+    public function testParseRanking(): void
+    {
+        $surveyConfig = new SurveyConfiguration(locales: ['default', 'nl']);
+        $questionConfig = [
+            'type' => 'ranking',
+            'name' => 'question1',
+            'choices' => [
+                'item1',
+                'item2',
+                'item3'
+            ],
+        ];
+
+        $parser = new OrderedVariableParser();
+
+        $result = toArray($parser->parse(new DummyParser(), $questionConfig, $surveyConfig));
+
+        self::assertInstanceOf(OrderedVariable::class, $result[0]);
+        $options = $result[0]->getValueOptions();
+
+        self::assertSame('item1', $options[0]->getDisplayValue());
+        self::assertSame('item2', $options[1]->getDisplayValue());
+        self::assertSame('item3', $options[2]->getDisplayValue());
+    }
+}

--- a/tests/Variables/OrderedVariableTest.php
+++ b/tests/Variables/OrderedVariableTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser\Tests\Variables;
+
+use Collecthor\DataInterfaces\Measure;
+use Collecthor\SurveyjsParser\ArrayRecord;
+use Collecthor\SurveyjsParser\Values\IntegerValueOption;
+use Collecthor\SurveyjsParser\Values\InvalidValue;
+use Collecthor\SurveyjsParser\Values\StringValueOption;
+use Collecthor\SurveyjsParser\Values\ValueSet;
+use Collecthor\SurveyjsParser\Variables\OrderedVariable;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Collecthor\SurveyjsParser\Variables\OrderedVariable
+ * @uses \Collecthor\SurveyjsParser\Values\IntegerValueOption
+ * @uses \Collecthor\SurveyjsParser\Values\StringValueOption
+ * @uses \Collecthor\SurveyjsParser\ArrayRecord
+ * @uses \Collecthor\SurveyjsParser\Values\StringValue
+ * @uses \Collecthor\SurveyjsParser\Values\InvalidValue
+ * @uses \Collecthor\SurveyjsParser\ArrayDataRecord
+ * @uses \Collecthor\SurveyjsParser\Values\ValueSet
+ */
+final class OrderedVariableTest extends TestCase
+{
+    public function testMeasureIsNominal(): void
+    {
+        $option = new IntegerValueOption(15, []);
+        $subject = new OrderedVariable("test", [], [$option], ['path']);
+        self::assertSame(Measure::Nominal, $subject->getMeasure());
+    }
+
+    public function testGetInvalidValues(): void
+    {
+        $valueOptions = [
+            new StringValueOption('test', ['en' => 'test', 'nl' => 'testnl']),
+            new StringValueOption('test2', ['en' => 'test-2', 'nl' => 'testnl2']),
+            new StringValueOption('test3', ['en' => 'test-3', 'nl' => 'testnl3']),
+            new StringValueOption('test4', ['en' => 'test-4', 'nl' => 'testnl4']),
+        ];
+        $subject = new OrderedVariable('test', [], $valueOptions, ['path']);
+
+        $data = new ArrayRecord(['path' => ['test', 'bad data']], 1, new \DateTime(), new \DateTime());
+
+        $foundValue = $subject->getValue($data);
+
+        self::assertInstanceOf(InvalidValue::class, $foundValue);
+    }
+
+    public function testGetValidValues(): void
+    {
+        $valueOptions = [
+            new StringValueOption('test', ['en' => 'test', 'nl' => 'testnl']),
+            new StringValueOption('test2', ['en' => 'test-2', 'nl' => 'testnl2']),
+            new StringValueOption('test3', ['en' => 'test-3', 'nl' => 'testnl3']),
+            new StringValueOption('test4', ['en' => 'test-4', 'nl' => 'testnl4']),
+        ];
+        $subject = new OrderedVariable('test', [], $valueOptions, ['path']);
+
+        $data = new ArrayRecord(['path' => ['test', 'test2']], 1, new \DateTime(), new \DateTime());
+
+        $foundValue = $subject->getValue($data);
+
+        self::assertInstanceOf(ValueSet::class, $foundValue);
+
+        /** @var StringValueOption[] $values */
+        $values = $foundValue->getValues();
+
+        self::assertSame($values[0]->getRawValue(), 'test');
+        self::assertSame($values[1]->getRawValue(), 'test2');
+
+        self::assertSame('test, test-2', $subject->getDisplayValue($data)->getRawValue());
+        self::assertSame('testnl, testnl2', $subject->getDisplayValue($data, 'nl')->getRawValue());
+    }
+
+    public function testGetCorrectOrdering(): void
+    {
+        $valueOptions = [
+            new StringValueOption('test', ['en' => 'test', 'nl' => 'testnl']),
+            new StringValueOption('test2', ['en' => 'test-2', 'nl' => 'testnl2']),
+            new StringValueOption('test3', ['en' => 'test-3', 'nl' => 'testnl3']),
+            new StringValueOption('test4', ['en' => 'test-4', 'nl' => 'testnl4']),
+        ];
+        $subject = new OrderedVariable('test', [], $valueOptions, ['path']);
+
+        $data = new ArrayRecord(['path' => ['test', 'test2', 'test3', 'test4']], 1, new \DateTime(), new \DateTime());
+
+        $foundValue = $subject->getValue($data);
+
+        self::assertInstanceOf(ValueSet::class, $foundValue);
+
+        /** @var StringValueOption[] $values */
+        $values = $foundValue->getValues();
+
+        self::assertSame($values[0]->getRawValue(), 'test');
+        self::assertSame($values[1]->getRawValue(), 'test2');
+        self::assertSame($values[2]->getRawValue(), 'test3');
+        self::assertSame($values[3]->getRawValue(), 'test4');
+
+        $data = new ArrayRecord(['path' => ['test3', 'test4', 'test', 'test2']], 1, new \DateTime(), new \DateTime());
+
+        $foundValue = $subject->getValue($data);
+
+        self::assertInstanceOf(ValueSet::class, $foundValue);
+
+        /** @var StringValueOption[] $values */
+        $values = $foundValue->getValues();
+
+        self::assertSame($values[0]->getRawValue(), 'test3');
+        self::assertSame($values[1]->getRawValue(), 'test4');
+        self::assertSame($values[2]->getRawValue(), 'test');
+        self::assertSame($values[3]->getRawValue(), 'test2');
+    }
+}


### PR DESCRIPTION
For question types such as a ranking, having a variable type with an order in it is a good idea, to keep all information such as this intact. This PR implements this and also has tests for this!