### PR TITLE
feat: add parser for no ui slider widget

### DIFF
--- a/src/Parsers/NoUISliderParser.php
+++ b/src/Parsers/NoUISliderParser.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser\Parsers;
+
+use Collecthor\SurveyjsParser\ElementParserInterface;
+use Collecthor\SurveyjsParser\ParserHelpers;
+use Collecthor\SurveyjsParser\SurveyConfiguration;
+use Collecthor\SurveyjsParser\Variables\NumericVariable;
+
+final class NoUISliderParser implements ElementParserInterface
+{
+    use ParserHelpers;
+    
+    public function parse(ElementParserInterface $root, array $questionConfig, SurveyConfiguration $surveyConfiguration, array $dataPrefix = []): iterable
+    {
+        $valueName = $this->extractValueName($questionConfig);
+        $titles = $this->extractTitles($questionConfig, $surveyConfiguration);
+        yield new NumericVariable($valueName, $titles, [...$dataPrefix, $valueName]);
+    }
+}

--- a/tests/Parsers/NoUISliderParserTest.php
+++ b/tests/Parsers/NoUISliderParserTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collecthor\SurveyjsParser\Tests\Parsers;
+
+use Collecthor\SurveyjsParser\Parsers\DummyParser;
+use Collecthor\SurveyjsParser\Parsers\NoUISliderParser;
+use Collecthor\SurveyjsParser\SurveyConfiguration;
+use Collecthor\SurveyjsParser\Variables\NumericVariable;
+use PHPUnit\Framework\TestCase;
+
+use function iter\toArray;
+
+/**
+ * @covers \Collecthor\SurveyjsParser\Parsers\NoUISliderParser
+ */
+final class NoUISliderParserTest extends TestCase
+{
+    public function testParseDefault(): void
+    {
+        $surveyConfig = new SurveyConfiguration();
+
+        $questionConfig = [
+            "type" => "nouislider",
+            "name" => "question1",
+        ];
+
+        $parser = new NoUISliderParser();
+
+        $result = toArray($parser->parse(new DummyParser(), $questionConfig, $surveyConfig))[0];
+
+        self::assertInstanceOf(NumericVariable::class, $result);
+        self::assertSame("question1", $result->getTitle());
+    }
+}

--- a/tests/Parsers/NoUISliderParserTest.php
+++ b/tests/Parsers/NoUISliderParserTest.php
@@ -14,6 +14,7 @@ use function iter\toArray;
 
 /**
  * @covers \Collecthor\SurveyjsParser\Parsers\NoUISliderParser
+ * @uses \Collecthor\SurveyjsParser\Variables\NumericVariable
  */
 final class NoUISliderParserTest extends TestCase
 {


### PR DESCRIPTION
Tests are quite limited, but all this parser does is create a numeric variable, in every case. Since this parser does not distinguish between Integer and Float variables and also does not have a minimum/maximum, this makes a very simple implementation