### PR TITLE
fix: use the correct way to generate the name of multiple choice questions

### DIFF
--- a/src/Parsers/MultipleChoiceQuestionParser.php
+++ b/src/Parsers/MultipleChoiceQuestionParser.php
@@ -9,6 +9,7 @@ use Collecthor\SurveyjsParser\ParserHelpers;
 use Collecthor\SurveyjsParser\SurveyConfiguration;
 use Collecthor\SurveyjsParser\Values\StringValueOption;
 use Collecthor\SurveyjsParser\Variables\MultipleChoiceVariable;
+use function implode;
 
 final class MultipleChoiceQuestionParser implements ElementParserInterface
 {
@@ -18,7 +19,7 @@ final class MultipleChoiceQuestionParser implements ElementParserInterface
     {
         $dataPath = [...$dataPrefix, $this->extractValueName($questionConfig)];
 
-        $name = $this->extractName($questionConfig);
+        $name = implode(".", $dataPath);
 
         $titles = $this->extractTitles($questionConfig);
 


### PR DESCRIPTION
When using a nested multiple choice question, for example in a Multiple choice matrix, the name of the question is only the name of the multiple choice question, but not the full path. This fixes this