### PR TITLE
Support `storeOthersAsComment`

### DIFF
--- a/src/Parsers/MultipleChoiceQuestionParser.php
+++ b/src/Parsers/MultipleChoiceQuestionParser.php
@@ -33,6 +33,10 @@ final class MultipleChoiceQuestionParser implements ElementParserInterface
 
         $choices = $this->extractChoices($this->extractArray($questionConfig, 'choices'));
 
+        if (!$surveyConfiguration->storeOthersAsComment && isset($questionConfig['choicesFromQuestion']) && is_string($questionConfig['choicesFromQuestion'])) {
+            throw new Exception('The combination of choicesFromQuestion and storeOthersAsComment is not supported yet');
+        }
+
         // Check if we need to add options for `hasNone` or `hasOther`
         if ($this->extractOptionalBoolean($questionConfig, 'hasNone') ?? false) {
             $choices[] = new StringValueOption('none', $this->extractLocalizedTexts($questionConfig, 'noneText'));
@@ -47,9 +51,6 @@ final class MultipleChoiceQuestionParser implements ElementParserInterface
         }
         // choicesFromQuestion
         if (isset($questionConfig['choicesFromQuestion']) && is_string($questionConfig['choicesFromQuestion'])) {
-            if (!$surveyConfiguration->storeOthersAsComment) {
-                throw new Exception('The combination of choicesFromQuestion and storeOthersAsComment is not supported yet');
-            }
             yield new DeferredVariable(
                 $name,
                 static function (ResolvableVariableSet $set) use ($name, $titles, $dataPath, $questionConfig): VariableInterface {

--- a/src/Parsers/SingleChoiceQuestionParser.php
+++ b/src/Parsers/SingleChoiceQuestionParser.php
@@ -17,6 +17,7 @@ use Collecthor\SurveyjsParser\Variables\OpenTextVariable;
 use Collecthor\SurveyjsParser\Variables\SingleChoiceVariable;
 use Exception;
 use ValueError;
+use function is_string;
 
 class SingleChoiceQuestionParser implements ElementParserInterface
 {
@@ -44,6 +45,9 @@ class SingleChoiceQuestionParser implements ElementParserInterface
                 $choices[] = new IntegerValueOption($i, ['default' => (string) $i]);
             }
         }
+        if (!$surveyConfiguration->storeOthersAsComment && isset($questionConfig['choicesFromQuestion']) && is_string($questionConfig['choicesFromQuestion'])) {
+            throw new Exception('The combination of choicesFromQuestion and storeOthersAsComment is not supported yet');
+        }
 
         // Check if we need to add options for `hasNone` or `hasOther`
         if ($this->extractOptionalBoolean($questionConfig, 'hasNone') ?? false) {
@@ -60,9 +64,6 @@ class SingleChoiceQuestionParser implements ElementParserInterface
 
         // choicesFromQuestion
         if (isset($questionConfig['choicesFromQuestion']) && is_string($questionConfig['choicesFromQuestion'])) {
-            if (!$surveyConfiguration->storeOthersAsComment) {
-                throw new Exception('The combination of choicesFromQuestion and storeOthersAsComment is not supported yet');
-            }
             yield new DeferredVariable(
                 $id,
                 static function (ResolvableVariableSet $set) use ($id, $titles, $dataPath, $questionConfig): VariableInterface {

--- a/src/SurveyConfiguration.php
+++ b/src/SurveyConfiguration.php
@@ -12,6 +12,7 @@ class SurveyConfiguration
 {
     public function __construct(
         public readonly string $commentPostfix = '-Comment',
+        public readonly bool $storeOthersAsComment = true,
     ) {
     }
 }

--- a/src/SurveyParser.php
+++ b/src/SurveyParser.php
@@ -23,6 +23,8 @@ use Collecthor\SurveyjsParser\Parsers\SingleChoiceQuestionParser;
 use Collecthor\SurveyjsParser\Parsers\TextQuestionParser;
 use Collecthor\SurveyjsParser\Variables\DeferredVariable;
 use Collecthor\SurveyjsParser\Variables\OpenTextVariable;
+use function is_bool;
+use function is_string;
 
 class SurveyParser implements SurveyParserInterface
 {
@@ -174,7 +176,10 @@ class SurveyParser implements SurveyParserInterface
          * Get some global settings from the survey structure. Note surveyJS incorrectly calls this a prefix
          * https://surveyjs.io/Documentation/Library?id=surveymodel#commentPrefix
          */
-        $surveyConfiguration = new SurveyConfiguration($this->extractString($structure, 'commentPrefix', '-Comment'));
+        $surveyConfiguration = new SurveyConfiguration(
+            $this->extractString($structure, 'commentPrefix', '-Comment'),
+            $this->extractBoolean($structure, 'storeOthersAsComment', true),
+        );
 
         if (isset($structure['pages']) && is_array($structure['pages'])) {
             foreach ($structure['pages'] as $page) {
@@ -230,6 +235,17 @@ class SurveyParser implements SurveyParserInterface
     {
         if (isset($config[$key]) && is_string($config[$key])) {
             return $key;
+        }
+        return $defaultValue;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function extractBoolean(array $config, string $key, bool $defaultValue): bool
+    {
+        if (isset($config[$key]) && is_bool($config[$key])) {
+            return $config[$key];
         }
         return $defaultValue;
     }

--- a/tests/Parsers/MultipleChoiceQuestionParserTest.php
+++ b/tests/Parsers/MultipleChoiceQuestionParserTest.php
@@ -58,7 +58,7 @@ final class MultipleChoiceQuestionParserTest extends TestCase
         self::assertSame('abc', $options[3]->getDisplayValue());
     }
 
-    public function testStoreDontOthersAsComment(): void
+    public function testDontStoreOthersAsComment(): void
     {
         $questionConfig = [
             'name' => 'test',

--- a/tests/Parsers/SingleChoiceQuestionParserTest.php
+++ b/tests/Parsers/SingleChoiceQuestionParserTest.php
@@ -192,7 +192,7 @@ final class SingleChoiceQuestionParserTest extends TestCase
         self::assertSame($valueOptions, $resolved->getValueOptions());
     }
 
-    public function testStoreDontOthersAsComment(): void
+    public function testDontStoreOthersAsComment(): void
     {
         $questionConfig = [
             'name' => 'test',


### PR DESCRIPTION
closes #31 

Only one thing I am not entirely sure about: When throwing an error when using `choicesFromQuestion` and `storeOthersAsComment` together, what kind of error to use? PHP does not seem to have a native sort of "notimplementederror", therefore it uses just a broad `Exception`, which does not seem like something good.

