### PR TITLE
fix: Use question celltype when column does not have cell type

### DIFF
--- a/src/Parsers/MultipleChoiceMatrixParser.php
+++ b/src/Parsers/MultipleChoiceMatrixParser.php
@@ -40,7 +40,7 @@ final class MultipleChoiceMatrixParser implements ElementParserInterface
                     $columnQuestion['hasNone'] = true;
                 }
                 $columnQuestion['title'] = $title;
-                $columnQuestion['type'] = $column['cellType'] ?? 'dropdown';
+                $columnQuestion['type'] = $column['cellType'] ?? $questionConfig['cellType'] ?? 'dropdown';
                 $columnQuestion['choices'] = $columnQuestion['choices'] ?? $defaultChoices;
                 yield from $root->parse($root, $columnQuestion, $surveyConfiguration, $prefix);
             }


### PR DESCRIPTION
When a column did not have a cell type, but the question had one, previously, there would be a fallback to the default. Now we use the question cell type.