### PR TITLE
fix: return BooleanValueOption from BooleanVariable

### DIFF
--- a/src/Variables/BooleanVariable.php
+++ b/src/Variables/BooleanVariable.php
@@ -11,7 +11,6 @@ use Collecthor\DataInterfaces\StringValueInterface;
 use Collecthor\SurveyjsParser\Traits\GetName;
 use Collecthor\SurveyjsParser\Traits\GetRawConfiguration;
 use Collecthor\SurveyjsParser\Traits\GetTitle;
-use Collecthor\SurveyjsParser\Values\BooleanValue;
 use Collecthor\SurveyjsParser\Values\BooleanValueOption;
 use Collecthor\SurveyjsParser\Values\InvalidValue;
 use Collecthor\SurveyjsParser\Values\MissingBooleanValue;
@@ -46,7 +45,7 @@ final class BooleanVariable implements ClosedVariableInterface
         ];
     }
 
-    public function getValue(RecordInterface $record): BooleanValue | MissingBooleanValue | InvalidValue
+    public function getValue(RecordInterface $record): BooleanValueOption | MissingBooleanValue | InvalidValue
     {
         $dataValue = $record->getDataValue($this->dataPath);
         if (is_null($dataValue)) {
@@ -55,7 +54,7 @@ final class BooleanVariable implements ClosedVariableInterface
         if (!is_bool($dataValue)) {
             return new InvalidValue($dataValue);
         }
-        return new BooleanValue($dataValue);
+        return new BooleanValueOption($dataValue, $dataValue ? $this->trueLabels : $this->falseLabels);
     }
 
     public function getDisplayValue(RecordInterface $record, ?string $locale = 'default'): StringValueInterface

--- a/tests/Variables/BooleanVariableTest.php
+++ b/tests/Variables/BooleanVariableTest.php
@@ -6,7 +6,7 @@ namespace Collecthor\SurveyjsParser\Tests\Variables;
 
 use Collecthor\DataInterfaces\Measure;
 use Collecthor\SurveyjsParser\ArrayRecord;
-use Collecthor\SurveyjsParser\Values\BooleanValue;
+use Collecthor\SurveyjsParser\Values\BooleanValueOption;
 use Collecthor\SurveyjsParser\Values\InvalidValue;
 use Collecthor\SurveyjsParser\Values\MissingBooleanValue;
 use Collecthor\SurveyjsParser\Variables\BooleanVariable;
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
  * @uses \Collecthor\SurveyjsParser\ArrayDataRecord
  * @uses \Collecthor\SurveyjsParser\Values\InvalidValue
  * @uses \Collecthor\SurveyjsParser\Values\BooleanValue
+ * @uses \Collecthor\SurveyjsParser\Values\BooleanValueOption
  * @uses \Collecthor\SurveyjsParser\Values\StringValue
  * @uses \Collecthor\SurveyjsParser\Values\MissingBooleanValue
  */
@@ -86,7 +87,7 @@ final class BooleanVariableTest extends TestCase
 
         $value = $subject->getValue($record);
 
-        self::assertInstanceOf(BooleanValue::class, $value);
+        self::assertInstanceOf(BooleanValueOption::class, $value);
         self::assertTrue($value->getRawValue());
     }
 
@@ -110,7 +111,7 @@ final class BooleanVariableTest extends TestCase
 
         $value = $subject->getValue($record);
 
-        self::assertInstanceOf(BooleanValue::class, $value);
+        self::assertInstanceOf(BooleanValueOption::class, $value);
         self::assertTrue($value->getRawValue());
         $displayValue = $subject->getDisplayValue($record)->getRawValue();
         self::assertEquals('true', $displayValue);


### PR DESCRIPTION
BooleanVariable returned a BooleanValue instead of a BooleanValueOption, while it was a closedvariable.